### PR TITLE
Use base-orphans to import Foldable/Traversable orphan instances

### DIFF
--- a/src/Data/Witherable.hs
+++ b/src/Data/Witherable.hs
@@ -28,6 +28,7 @@ import Data.Functor.Identity
 import Control.Monad.Trans.Maybe
 import Control.Monad.Trans.State.Strict
 import Data.Monoid
+import Data.Orphans ()
 #if (MIN_VERSION_base(4,7,0))
 import Data.Proxy
 #endif
@@ -148,22 +149,6 @@ instance (Eq k, Hashable k) => Witherable (HM.HashMap k) where
 #if (MIN_VERSION_base(4,7,0))
 instance Witherable Proxy where
   wither _ Proxy = pure Proxy
-#endif
-
-#if !(MIN_VERSION_base(4,7,0))
-instance F.Foldable (Const r) where
-  foldMap _ _ = mempty
-
-instance T.Traversable (Const r) where
-  traverse _ (Const r) = pure (Const r)
-
-instance F.Foldable (Either a) where
-  foldMap _ (Left _) = mempty
-  foldMap f (Right a) = f a
-
-instance T.Traversable (Either a) where
-  traverse _ (Left x) = pure (Left x)
-  traverse f (Right y) = Right <$> f y
 #endif
 
 instance Witherable (Const r) where

--- a/witherable.cabal
+++ b/witherable.cabal
@@ -17,6 +17,12 @@ library
   exposed-modules:     Data.Witherable
   -- other-modules:
   -- other-extensions:
-  build-depends:       base == 4.*, containers, vector, unordered-containers, hashable, transformers
+  build-depends:       base == 4.*,
+                       base-orphans,
+                       containers,
+                       hashable,
+                       transformers,
+                       unordered-containers,
+                       vector
   hs-source-dirs:      src
   default-language:    Haskell2010


### PR DESCRIPTION
Currently, `witherable` defines orphan `Foldable`/`Traversable` instances for `Const` and `Either`. However, there are a number of other packages that also define these instances, including [`functor-combo`](https://github.com/conal/functor-combo/blob/885752a0b58a2e9e606401da9ed8a4f0fe823680/src/FunctorCombo/Functor.hs#L115-118), [`semigroupoids`](https://github.com/ekmett/semigroupoids/blob/99ce7a18876da749c49e8ee969ff03a340fb76af/src/Data/Traversable/Instances.hs#L36-56), and [`lens`](https://github.com/ekmett/lens/blob/7af45fb03374ef23a3658c17e692ea475f6bf585/src/Control/Lens/Internal/Instances.hs#L44-70), which means that if anyone were to use any combination of these libraries together on GHC 7.6 or earlier, it could lead to instance conflicts.

To help mitigate this possibility, this pull request imports these instances from the `base-orphans` library (which exports backported instances introduced in later versions of `base`, including the aforementioned ones). This way, we can keep all of these orphan instances in one package so that `functor-combo`, `witherable`, `semigroupoids`, `lens`, etc. can coexist.