### PR TITLE
Add forMaybe and forMaybeA

### DIFF
--- a/src/Data/Witherable.hs
+++ b/src/Data/Witherable.hs
@@ -13,6 +13,8 @@
 --
 -----------------------------------------------------------------------------
 module Data.Witherable (Witherable(..)
+  , forMaybe
+  , forMaybeA
   , witherM
   , blightM
   , ordNub
@@ -141,6 +143,16 @@ class T.Traversable t => Witherable t where
 #if defined(__GLASGOW_HASKELL__) && __GLASGOW_HASKELL__ >= 707
   {-# MINIMAL wither | mapMaybe | catMaybes #-}
 #endif
+
+-- | 'forMaybe' is 'mapMaybe' with its arguments flipped.
+forMaybe :: (Witherable t) => t a -> (a -> Maybe b) -> t b
+forMaybe = flip mapMaybe
+{-# INLINE forMaybe #-}
+
+-- | 'forMaybeA' is 'wither' with its arguments flipped.
+forMaybeA :: (Witherable t, Applicative f) => t a -> (a -> f (Maybe b)) -> f (t b)
+forMaybeA = flip wither
+{-# INLINE forMaybeA #-}
 
 witherM :: (Witherable t, Monad m) => (a -> MaybeT m b) -> t a -> m (t b)
 witherM f = unwrapMonad . wither (WrapMonad . runMaybeT . f)


### PR DESCRIPTION
These are useful for expressions like
```haskell
forMaybeA things $ \thing -> do
  doX
  doY
  ...
```

Regarding `forMaybeA` I'm afraid I couldn't come up with a better name name. It's consistent with with `forMaybe` and `filterA` at least.