### PR TITLE
Possibly correct documentation error

### DIFF
--- a/src/Data/Witherable.hs
+++ b/src/Data/Witherable.hs
@@ -202,7 +202,7 @@ hashNubOf w t = evalState (w f t) HSet.empty
 {-# INLINE hashNubOf #-}
 
 -- | Removes duplicate elements from a list, keeping only the first
---   occurrence. This is exponentially quicker than using
+--   occurrence. This is asymptotically faster than using
 --   'Data.List.nub' from "Data.List".
 ordNub :: (Witherable t, Ord a) => t a -> t a
 ordNub = ordNubOf wither


### PR DESCRIPTION
`ordNub`'s documentation claims to be "exponentially quicker" than `nub` from Prelude, but unless I misunderstand, `ordNub` is O(n*log(n)) and `nub` is O(n^2), which is less than a factor of `n` improvement, which is not "exponentially" faster.