### PR TITLE
fix conservation law for Witherable. add conservation law to Filterable

### DIFF
--- a/src/Data/Witherable.hs
+++ b/src/Data/Witherable.hs
@@ -132,6 +132,9 @@ filterOf w f = runIdentity . filterAOf w (Identity . f)
 -- [/identity/]
 --   @'mapMaybe' Just ≡ id@
 --
+-- [/conservation/]
+--   @'mapMaybe' (Just . f) ≡ 'fmap' f@
+--
 -- [/composition/]
 --   @'mapMaybe' f . 'mapMaybe' g ≡ 'mapMaybe' (f <=< g)@
 class Functor f => Filterable f where
@@ -162,7 +165,7 @@ class Functor f => Filterable f where
 --   @'wither' ('pure' . Just) ≡ 'pure'@
 --
 -- [/conservation/]
---   @'wither' (f . Just) ≡ 'traverse' f@
+--   @'wither' ('fmap' 'Just' . f) ≡ 'traverse' f@
 --
 -- [/composition/]
 --   @'Compose' . 'fmap' ('wither' f) . 'wither' g ≡ 'wither' ('Compose' . 'fmap' ('wither' f) . g)@


### PR DESCRIPTION
The conservation law I had added to `Witherable` was ill-typed. Also, I added a similar law to `Filterable`. Currently, the laws for `Filterable` are:

    mapMaybe Just ≡ id
    mapMaybe f . mapMaybe g ≡ mapMaybe (f <=< g)

We are currently missing anything that relates the to the superclass `Functor` constraint. It's possible that the law I've added is actually implied by the identity law, but I cannot tell.