### PR TITLE
Put a lower bound on containers

### DIFF
--- a/witherable.cabal
+++ b/witherable.cabal
@@ -24,7 +24,7 @@ library
   -- other-extensions:
   build-depends:       base == 4.*,
                        base-orphans,
-                       containers,
+                       containers >= 0.5,
                        hashable,
                        transformers,
                        unordered-containers,


### PR DESCRIPTION
We depend on Data.Map.Lazy, meaning that we need a containers version
at or above 0.5. This fixes the build on GHC 7.4 and below.