### PR TITLE
Add transformers-compat dependency

### DIFF
--- a/witherable.cabal
+++ b/witherable.cabal
@@ -27,6 +27,7 @@ library
                        containers >= 0.5,
                        hashable,
                        transformers,
+                       transformers-compat,
                        unordered-containers,
                        vector
   hs-source-dirs:      src


### PR DESCRIPTION
`Data.Functor.Sum` appears to have some weird history I don't
understand (it kind of looks like it might have moved twice
or accidentally disappeared at one point). Let's see if adding
a `transformers-compat` dependency will fix that.