### PR TITLE
Add changelog entries for infix operators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+0.3.1
+-------
+* Added `(<$?>)` as an alias for `mapMaybe`, with fixity matching `(<$>)`.
+* Added `(<&?>) = flip (<$?>)`, with fixity matching `(<&>)`.
+
 0.3
 -------
 * Added `(Filterable f, Filterable g) => Filterable (Product f g)`


### PR DESCRIPTION
I forgot a changelog entry for the new infix operators. This PR corrects that.