### PR TITLE
Add indexed operations.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+Next
+-------
+
+* Added `FilterableWithIndex` and `WitherableWithIndex`.
+
 0.3.2
 ----------
 

--- a/witherable.cabal
+++ b/witherable.cabal
@@ -26,6 +26,7 @@ library
                        base-orphans,
                        containers >= 0.5,
                        hashable,
+                       lens,
                        monoidal-containers,
                        transformers,
                        transformers-compat,


### PR DESCRIPTION
This incurs a direct dependency on `lens`, but there is already a
transitive dependency going through `monoidal-map`.

I didn't add `IndexedFilter` and allies, mostly because it was
complicated and isn't necessary to get something useful here - just
being able to generalise `traverseMapWithKey` is quite handy already.

Closes #40.