### PR TITLE
Fix short-circuiting behavior of the `filter` law.

### DIFF
--- a/witherable-class/Data/Witherable/Class.hs
+++ b/witherable-class/Data/Witherable/Class.hs
@@ -76,7 +76,7 @@ class Functor f => Filterable f where
   catMaybes = mapMaybe id
   {-# INLINE catMaybes #-}
 
-  -- | @'filter' f . 'filter' g ≡ filter ('liftA2' ('&&') f g)@
+  -- | @'filter' f . 'filter' g ≡ filter ('liftA2' ('&&') g f)@
   filter :: (a -> Bool) -> f a -> f a
   filter f = mapMaybe $ \a -> if f a then Just a else Nothing
   {-# INLINE filter #-}


### PR DESCRIPTION
`(&&)` evaluates its left hand side first, short-circuiting and not evaluating its right hand side when the left side is `False`. In `filter f . filter g`, `g` is evaluated first. This might come up in practice with a situation like `filter (\(Just x) -> p x) . filter isJust`, where testing the left condition first would produce bottom.