### PR TITLE
Instances for Generics.K1

### DIFF
--- a/witherable-class/Data/Witherable/Class.hs
+++ b/witherable-class/Data/Witherable/Class.hs
@@ -352,6 +352,15 @@ instance Witherable Generics.U1 where
   wither _ _ = pure Generics.U1
   filterA _ _ = pure Generics.U1
 
+instance Filterable (Generics.K1 i c) where
+  mapMaybe _ (Generics.K1 a) = Generics.K1 a
+  catMaybes (Generics.K1 a) = Generics.K1 a
+  filter _ (Generics.K1 a) = Generics.K1 a
+
+instance Witherable (Generics.K1 i c) where
+  wither _ (Generics.K1 a) = pure (Generics.K1 a)
+  filterA _ (Generics.K1 a) = pure (Generics.K1 a)
+
 instance Filterable f => Filterable (Generics.Rec1 f) where
   mapMaybe f (Generics.Rec1 a) = Generics.Rec1 (mapMaybe f a)
   catMaybes (Generics.Rec1 a) = Generics.Rec1 (catMaybes a)


### PR DESCRIPTION
These instances provide Filterable and Witherable for records:
```
data Example a = Example {
    someNumber :: Int,
    things :: [a]
} deriving Generic1

instance Filterable Example where
    catMaybes = to1 . catMaybes . from1
    mapMaybe f = to1 . mapMaybe f . from1
    filter p = to1 . filter p . from1

instance Witherable Example where
    wither f = fmap to1 . wither f . from1
    filterA p = fmap to1 . filterA p . from1
```
Do they have any adverse effects or break any laws?