### PR TITLE
Fixes for GHC 9.2

### DIFF
--- a/witherable/src/Data/Witherable.hs
+++ b/witherable/src/Data/Witherable.hs
@@ -96,7 +96,7 @@ instance Applicative (Peat a b) where
 
 -- | Reconstitute a 'Filter' from its monomorphic form.
 cloneFilter :: FilterLike (Peat a b) s t a b -> Filter s t a b
-cloneFilter l f = (`runPeat` f) . l (\a -> Peat $ \g -> g a)
+cloneFilter l f = (\a -> a `runPeat` f) . l (\a -> Peat $ \g -> g a)
 {-# INLINABLE cloneFilter #-}
 
 -- | 'witherOf' is actually 'id', but left for consistency.

--- a/witherable/src/Witherable.hs
+++ b/witherable/src/Witherable.hs
@@ -54,7 +54,9 @@ import Data.Hashable
 import Data.Monoid
 import Data.Orphans ()
 import Data.Proxy
+#if !MIN_VERSION_base(4,16,0)
 import Data.Semigroup (Option (..))
+#endif
 import Data.Traversable.WithIndex
 import Data.Void
 import Prelude hiding (filter)
@@ -174,6 +176,8 @@ instance Witherable Maybe where
   wither f (Just a) = f a
   {-# INLINABLE wither #-}
 
+#if !MIN_VERSION_base(4,16,0)
+
 instance Filterable Option where
   mapMaybe f = (>>= Option . f)
   {-# INLINE mapMaybe #-}
@@ -185,6 +189,8 @@ instance Witherable Option where
 -- Option doesn't have the necessary instances in Lens
 --instance FilterableWithIndex () Option
 --instance WitherableWithIndex () Option
+
+#endif
 
 instance Monoid e => Filterable (Either e) where
   mapMaybe _ (Left e) = Left e


### PR DESCRIPTION
Checked with

```cabal
packages:
  ./witherable/
  ./witherable-class/

allow-newer:
  indexed-traversable-instances:base,
  indexed-traversable:base,
  quickcheck-instances:base,
  splitmix:base,
  time-compat:base,
  these:base,
  assoc:base,
  integer-logarithms:base,
  integer-logarithms:ghc-bignum,
  integer-logarithms:ghc-prim,
  data-fix:base
```