### PR TITLE
Deal with lists, sequences, vectors properly

### DIFF
--- a/witherable/src/Witherable.hs
+++ b/witherable/src/Witherable.hs
@@ -9,7 +9,7 @@
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Witherable
--- Copyright   :  (c) Fumiaki Kinoshita 2020
+-- Copyright   :  (c) Fumiaki Kinoshita 2020-23
 -- License     :  BSD3
 --
 -- Maintainer  :  Fumiaki Kinoshita <fumiexcel@gmail.com>
@@ -26,6 +26,7 @@ module Witherable
   , ordNubOn
   , hashNub
   , hashNubOn
+  , defaultiwither
   , forMaybe
   -- * Indexed variants
   , FilterableWithIndex(..)
@@ -489,6 +490,13 @@ class (TraversableWithIndex i t, Witherable t) => WitherableWithIndex i t | t ->
 
   ifilterA :: (Applicative f) => (i -> a -> f Bool) -> t a -> f (t a)
   ifilterA f = iwither (\i a -> (\b -> if b then Just a else Nothing) <$> f i a)
+
+-- | The conditions under which 'iwither' is defined are weaker than
+-- 'Witherable': for example, lists, vectors and sequences do not have
+-- lawful 'Witherable' instances but this function may nevertheless be
+-- useful.
+defaultiwither :: (Applicative f, Filterable t, TraversableWithIndex i t) => (i -> a -> f (Maybe b)) -> t a -> f (t b)
+defaultiwither f = fmap catMaybes . itraverse f
 
 instance FilterableWithIndex () Maybe
 

--- a/witherable/src/Witherable.hs
+++ b/witherable/src/Witherable.hs
@@ -498,14 +498,6 @@ instance WitherableWithIndex () Maybe
 --instance FilterableWithIndex () Option
 --instance WitherableWithIndex () Option
 
-instance FilterableWithIndex Int []
-
-instance FilterableWithIndex Int ZipList
-
-instance WitherableWithIndex Int []
-
-instance WitherableWithIndex Int ZipList
-
 instance FilterableWithIndex Int IM.IntMap where
   imapMaybe = IM.mapMaybeWithKey
   ifilter = IM.filterWithKey
@@ -530,16 +522,6 @@ instance (Eq k, Hashable k) => WitherableWithIndex k (HM.HashMap k) where
 instance FilterableWithIndex Void Proxy
 
 instance WitherableWithIndex Void Proxy
-
-instance FilterableWithIndex Int V.Vector where
-  imapMaybe = V.imapMaybe
-  ifilter = V.ifilter
-
-instance WitherableWithIndex Int V.Vector
-
-instance FilterableWithIndex Int S.Seq
-
-instance WitherableWithIndex Int S.Seq
 
 instance (FunctorWithIndex i f, FilterableWithIndex j g) => FilterableWithIndex (i, j) (Compose f g) where
   imapMaybe f = Compose . imap (\i -> imapMaybe (\j -> f (i, j))) . getCompose


### PR DESCRIPTION
As described in detail in the first commit of this pull request, the instances for listlike data types are unlawful, and there is a danger that rewriting code (by hand, or by automated rule) will assume the laws (which are clearly stated elsewhere in the code) and hence introduce errors.

The functionality is still useful, and we introduce (in the second commit) a function which does the same job but claims no lawful behaviour and is substantially less likely to be a footgun.