### PR TITLE
Making WitherableWithIndex depend on FilterableWithIndex

### DIFF
--- a/witherable/src/Witherable.hs
+++ b/witherable/src/Witherable.hs
@@ -476,7 +476,7 @@ class (FunctorWithIndex i t, Filterable t) => FilterableWithIndex i t | t -> i w
   {-# INLINE ifilter #-}
 
 -- | Indexed variant of 'Witherable'.
-class (TraversableWithIndex i t, Witherable t) => WitherableWithIndex i t | t -> i where
+class (TraversableWithIndex i t, FilterableWithIndex i t, Witherable t) => WitherableWithIndex i t | t -> i where
   -- | Effectful 'imapMaybe'.
   --
   -- @'iwither' (\ i -> 'pure' . f i) ≡ 'pure' . 'imapMaybe' f@


### PR DESCRIPTION
This is a natural extension, and it's nice not to pollute your codebase with unnecessary assumptions to have access to the functionality.