### PR TITLE
Adding 'flush' method

### DIFF
--- a/witherable/src/Witherable.hs
+++ b/witherable/src/Witherable.hs
@@ -100,6 +100,11 @@ class Functor f => Filterable f where
   filter f = mapMaybe $ \a -> if f a then Just a else Nothing
   {-# INLINE filter #-}
 
+  -- | Empty a filterable; often this is a constant map.
+  flush :: f a -> f b
+  flush = mapMaybe (const Nothing)
+  {-# INLINE flush #-}
+
   {-# MINIMAL mapMaybe | catMaybes #-}
 
 -- | An enhancement of 'Traversable' with 'Filterable'
@@ -169,6 +174,7 @@ class (T.Traversable t, Filterable t) => Witherable t where
 
 instance Filterable Maybe where
   mapMaybe f = (>>= f)
+  flush _ = Nothing
   {-# INLINE mapMaybe #-}
 
 instance Witherable Maybe where
@@ -206,11 +212,13 @@ instance Filterable [] where
   mapMaybe = Maybe.mapMaybe
   catMaybes = Maybe.catMaybes
   filter = Prelude.filter
+  flush _ = []
 
 instance Filterable ZipList where
   mapMaybe f = ZipList . Maybe.mapMaybe f . getZipList
   catMaybes = ZipList . Maybe.catMaybes . getZipList
   filter f = ZipList . Prelude.filter f . getZipList
+  flush _ = ZipList []
 
 -- | Methods are good consumers for fusion.
 instance Witherable [] where
@@ -236,12 +244,14 @@ instance Witherable ZipList where
 instance Filterable IM.IntMap where
   mapMaybe = IM.mapMaybe
   filter = IM.filter
+  flush _ = IM.empty
 
 instance Witherable IM.IntMap where
 
 instance Filterable (M.Map k) where
   mapMaybe = M.mapMaybe
   filter = M.filter
+  flush _ = M.empty
 
 instance Witherable (M.Map k) where
 #if MIN_VERSION_containers(0,5,8)
@@ -251,6 +261,7 @@ instance Witherable (M.Map k) where
 instance (Eq k, Hashable k) => Filterable (HM.HashMap k) where
   mapMaybe = HM.mapMaybe
   filter = HM.filter
+  flush _ = HM.empty
 
 instance (Eq k, Hashable k) => Witherable (HM.HashMap k) where
 
@@ -271,6 +282,7 @@ instance Witherable (Const r) where
 instance Filterable V.Vector where
   filter   = V.filter
   mapMaybe = V.mapMaybe
+  flush _  = V.empty
 
 instance Witherable V.Vector where
   wither f = fmap V.fromList . wither f . V.toList
@@ -283,6 +295,7 @@ instance Filterable S.Seq where
   mapMaybe f = S.fromList . mapMaybe f . F.toList
   {-# INLINABLE mapMaybe #-}
   filter = S.filter
+  flush _ = S.empty
 
 instance Witherable S.Seq where
   wither f = fmap S.fromList . wither f . F.toList
@@ -313,6 +326,7 @@ instance (Functor f, Filterable g) => Filterable (Compose f g) where
   mapMaybe f = Compose . fmap (mapMaybe f) . getCompose
   filter p = Compose . fmap (filter p) . getCompose
   catMaybes = Compose . fmap catMaybes . getCompose
+  flush = Compose . fmap flush . getCompose
 
 instance (T.Traversable f, Witherable g) => Witherable (Compose f g) where
   wither f = fmap Compose . T.traverse (wither f) . getCompose
@@ -323,6 +337,7 @@ instance (Filterable f, Filterable g) => Filterable (P.Product f g) where
   mapMaybe f (P.Pair x y) = P.Pair (mapMaybe f x) (mapMaybe f y)
   filter p (P.Pair x y) = P.Pair (filter p x) (filter p y)
   catMaybes (P.Pair x y) = P.Pair (catMaybes x) (catMaybes y)
+  flush (P.Pair x y) = P.Pair (flush x) (flush y)
 
 instance (Witherable f, Witherable g) => Witherable (P.Product f g) where
   wither f (P.Pair x y) = liftA2 P.Pair (wither f x) (wither f y)
@@ -338,6 +353,9 @@ instance (Filterable f, Filterable g) => Filterable (Sum.Sum f g) where
 
   filter p (Sum.InL x) = Sum.InL (filter p x)
   filter p (Sum.InR y) = Sum.InR (filter p y)
+
+  flush (Sum.InL x) = Sum.InL (flush x)
+  flush (Sum.InR y) = Sum.InR (flush y)
 
 instance (Witherable f, Witherable g) => Witherable (Sum.Sum f g) where
   wither f (Sum.InL x) = Sum.InL <$> wither f x


### PR DESCRIPTION
`mapMaybe (const Nothing)` is often a constant map, and being able to provide a short-cut is useful (you may think it's never used, but consider `dropMissing` in `Data.Map.Merge.Strict`).